### PR TITLE
Measure one coverage for all interpreters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,11 @@ envlist =
 [testenv]
 deps =
   pytest
+  pytest-cov
   mock
   PyYAML
 commands =
-  py.test {posargs:tests}
+  py.test --cov dooku --cov-append {posargs:tests}
 
 [testenv:docs]
 deps =
@@ -22,12 +23,3 @@ deps =
   flake8
 commands =
   flake8 {posargs:dooku tests}
-
-[testenv:coverage]
-basepython = python3
-deps =
-  pytest-cov
-  {[testenv]deps}
-commands =
-  coverage erase
-  py.test tests --cov dooku


### PR DESCRIPTION
It makes sense measure coverate for all interpreters at once (since the
code may have some "if py3.x" statements).